### PR TITLE
feat: ignore venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ npm-debug.log
 
 # General
 /duda-venv/
+/theDudaProject-venv/
 /venv/
 /env/
 /output/

--- a/theDudaProject-venv/pyvenv.cfg
+++ b/theDudaProject-venv/pyvenv.cfg
@@ -1,3 +1,3 @@
-home = /usr/bin
+home = /home/eduardavercosa/Downloads/theDudaProject/theDudaProject-venv/bin
 include-system-site-packages = false
 version = 3.8.5


### PR DESCRIPTION
## Objective and Motivation
- Ignoring the virtualenv to stop prospector error on circleCI